### PR TITLE
support digests titles

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,9 @@ clause sets defaults for the digest options in the rest of the file.  Each
   - If an item only needs to specify a GitHub URL, then it can simply be the
     URL string.
 
+- The optional ``title`` setting will be used to construct the title
+  and main header of the HTML page.
+
 Items can have additional options:
 
 - No activity is reported for bot users.  Some applications act as real users,

--- a/src/dinghy/digest.py
+++ b/src/dinghy/digest.py
@@ -480,6 +480,7 @@ async def make_digest(items, since="1 week", digest="digest.html", **options):
         since=since_date,
         now=datetime.datetime.now(),
         __version__=__version__,
+        title=options.get("title", ""),
     )
     logger.info(f"Wrote digest: {digest}")
 

--- a/src/dinghy/templates/digest.html.j2
+++ b/src/dinghy/templates/digest.html.j2
@@ -27,7 +27,7 @@
 {%- endmacro -%}
 
 <head>
-  <title>Activity since {{ since|datetime("%Y-%m-%d") }}</title>
+  <title>{% if title %}{{ title }} - {% endif %}Activity since {{ since|datetime("%Y-%m-%d") }}</title>
   <link rel="icon" href="{{ octicon_url("comment-discussion", 24) }}" type="image/svg+xml">
   <style>
   body {
@@ -179,7 +179,7 @@
   </style>
 <body>
 
-<h1>Activity since {{ since|datetime("%Y-%m-%d") }}</h1>
+<h1>{% if title %}{{ title }} - {% endif %}Activity since {{ since|datetime("%Y-%m-%d") }}</h1>
 
 <ul class="repos">
   {% for container in results -%}


### PR DESCRIPTION
If the `digest` clause includes a `title` key, prepend that string on
the default title in the HTML output.