### PR TITLE
Add meta tag specifying utf-8

### DIFF
--- a/src/dinghy/templates/digest.html.j2
+++ b/src/dinghy/templates/digest.html.j2
@@ -27,6 +27,7 @@
 {%- endmacro -%}
 
 <head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>{% if title %}{{ title }} - {% endif %}Activity since {{ since|datetime("%Y-%m-%d") }}</title>
   <link rel="icon" href="{{ octicon_url("comment-discussion", 24) }}" type="image/svg+xml">
   <style>


### PR DESCRIPTION
Without the charset:

<img width="731" alt="image" src="https://user-images.githubusercontent.com/7150/184220302-ae354c22-f62c-4fbf-9286-0e5f9d7d15bf.png">

With it:

<img width="718" alt="image" src="https://user-images.githubusercontent.com/7150/184220404-ec14b0ad-a9b9-4fbd-8b75-1de2a1bc437e.png">


closes #12