### PR TITLE
deps: don't allow aiohttp 4-alpha

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ package_dir =
     = src
 install_requires =
     aiofiles>=0.8
-    aiohttp>3
+    aiohttp>=3,<4
     click>8
     click-log>0.3
     emoji


### PR DESCRIPTION
aiohttp 4.0.0-alpha breaks the dinghy install on Python 3.11 release candidates and betas.

Fixes #16.