### PR TITLE
cli: provide entrypoint `dinghy`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Getting Started
 
    .. code-block:: bash
 
-    $ python -m dinghy https://github.com/Me/MyProject
+    $ dinghy https://github.com/Me/MyProject
     Wrote digest: digest.html
 
    You will have a digest of the repo's last week of activity in digest.html.

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,10 @@ dinghy =
     graphql/*.*
     templates/*.*
 
+[options.entry_points]
+console_scripts =
+    dinghy = dinghy.__main__
+
 [wheel]
 universal = 1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ dinghy =
 
 [options.entry_points]
 console_scripts =
-    dinghy = dinghy.__main__
+    dinghy = dinghy.__main__:cli
 
 [wheel]
 universal = 1


### PR DESCRIPTION
This commit provides a direct entrypoint for `dinghy`, preventing the need to type `pythonX.X -m dinghy`. This is of course quality of life only.