### PR TITLE
Override default since param only if explicitly provided by CLI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,20 @@ See the fragment files in the `scriv.d directory`_.
 
 .. scriv-insert-here
 
+.. _changelog-1.3.2:
+
+1.3.2 — 2023-09-19
+------------------
+
+Fixed
+.....
+
+- fix: override default since param only if explicitly provided by cli #36
+  952bdfb introduced a regression ignoring the `since` parameter defined via
+  YAML config in favor of the default defined by the cli option
+
+.. _issue 36: https://github.com/nedbat/dinghy/issues/36
+
 .. _changelog-1.3.1:
 
 1.3.1 — 2023-09-17

--- a/scriv.d/20230919_153108_ltvolks_since_default_override.rst
+++ b/scriv.d/20230919_153108_ltvolks_since_default_override.rst
@@ -1,8 +1,0 @@
-Fixed
-.....
-
-- fix: override default since param only if explicitly provided by cli #36
-  952bdfb introduced a regression ignoring the `since` parameter defined via
-  YAML config in favor of the default defined by the cli option
-
-.. _issue 36: https://github.com/nedbat/dinghy/issues/36

--- a/scriv.d/20230919_153108_ltvolks_since_default_override.rst
+++ b/scriv.d/20230919_153108_ltvolks_since_default_override.rst
@@ -1,0 +1,8 @@
+Fixed
+.....
+
+- fix: override default since param only if explicitly provided by cli #36
+  952bdfb introduced a regression ignoring the `since` parameter defined via
+  YAML config in favor of the default defined by the cli option
+
+.. _issue 36: https://github.com/nedbat/dinghy/issues/36

--- a/src/dinghy/__init__.py
+++ b/src/dinghy/__init__.py
@@ -2,4 +2,4 @@
 Dinghy daily digest tool.
 """
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"

--- a/src/dinghy/cli.py
+++ b/src/dinghy/cli.py
@@ -45,12 +45,14 @@ def main_run(coro):
 @click.option(
     "--since",
     metavar="DELTA-OR-DATE",
-    help="Specify a since date [default: 1 week].",
+    help="Specify a since date.",
     default="1 week",
+    show_default=True,
 )
 @click.argument("_input", metavar="[INPUT]", default="dinghy.yaml")
 @click.argument("digests", metavar="[DIGEST ...]", nargs=-1)
-def cli(since, _input, digests):
+@click.pass_context
+def cli(ctx, since, _input, digests):
     """
     Generate HTML digests of GitHub activity.
 
@@ -64,6 +66,8 @@ def cli(since, _input, digests):
     if "://" in _input:
         coro = make_digest([_input], since=since)
     else:
+        source = ctx.get_parameter_source("since")
+        since = None if source.name == "DEFAULT" else since
         coro = make_digests_from_config(_input, digests or None, since=since)
 
     main_run(coro)


### PR DESCRIPTION
Fixes #36 

Override default since param only if explicitly provided by cli

https://github.com/nedbat/dinghy/commit/952bdfb4123434a0cd5c0a0240ca3b134b55d791 introduced a regression ignoring the `since` parameter defined via YAML config in favor of the default defined by the cli option.