### PR TITLE
build: scope fromisoformat backport to python<3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">= 3.8"
 dependencies = [
     "aiofiles>=0.8",
     "aiohttp>3",
-    "backports-datetime-fromisoformat",
+    "backports-datetime-fromisoformat; python_version<'3.11'",
     "click>8",
     "click-log>0.3",
     "emoji",

--- a/scriv.d/20250105_214759_3806110+tjni_scope_backports.rst
+++ b/scriv.d/20250105_214759_3806110+tjni_scope_backports.rst
@@ -1,0 +1,4 @@
+Changed
+.......
+
+- Install backports-datetime-fromisoformat only on Python < 3.11


### PR DESCRIPTION
The backports-datetime-fromisoformat package has no effect on Python versions >= 3.11.