### PR TITLE
feat: add breadcrumbs with navigation at the top of the html page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ out_*.json
 save_*.json
 
 *.egg-info/
+__pycache__
 build/
 dist/
 lab/
+
+.idea

--- a/scriv.d/20250330_231110_amotl_breadcrumbs.rst
+++ b/scriv.d/20250330_231110_amotl_breadcrumbs.rst
@@ -1,0 +1,37 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the section that is right (remove the leading dots).
+.. For top level release notes, leave all the headers commented out.
+..
+.. Removed
+.. .......
+..
+.. - A bullet item for the Removed category.
+..
+Added
+.....
+
+- Added breadcrumbs with navigation at the top of the HTML page.
+  Specifically with many items per section, it makes navigating
+  so much easier.
+
+.. Changed
+.. .......
+..
+.. - A bullet item for the Changed category.
+..
+.. Deprecated
+.. ..........
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. .....
+..
+.. - A bullet item for the Fixed category.
+..
+.. Security
+.. ........
+..
+.. - A bullet item for the Security category.
+..

--- a/src/dinghy/helpers.py
+++ b/src/dinghy/helpers.py
@@ -5,6 +5,7 @@ Misc helpers.
 import datetime
 import json
 import re
+import unicodedata
 
 import aiofiles
 from backports.datetime_fromisoformat import MonkeyPatch
@@ -86,3 +87,25 @@ def find_dict_with_key(d, key):
             if sd is not None:
                 return sd
     return None
+
+
+def slugify(value, allow_unicode=False):
+    """
+    Convert to ASCII if 'allow_unicode' is False. Convert spaces or repeated
+    dashes to single dashes. Remove characters that aren't alphanumerics,
+    underscores, or hyphens. Convert to lowercase. Also strip leading and
+    trailing whitespace, dashes, and underscores.
+
+    from django.template.defaultfilters import slugify
+    """
+    value = str(value).strip()
+    if allow_unicode:
+        value = unicodedata.normalize("NFKC", value)
+    else:
+        value = (
+            unicodedata.normalize("NFKD", value)
+            .encode("ascii", "ignore")
+            .decode("ascii")
+        )
+    value = re.sub(r"[^\w\s-]", "", value.lower())
+    return re.sub(r"[-\s]+", "-", value).strip("-_")

--- a/src/dinghy/jinja_helpers.py
+++ b/src/dinghy/jinja_helpers.py
@@ -10,6 +10,8 @@ import aiofiles
 import emoji
 import jinja2
 
+from dinghy.helpers import slugify
+
 
 def datetime_format(value, fmt="%m-%d %H:%M"):
     """Format a datetime or ISO datetime string, for Jinja filtering."""
@@ -43,6 +45,7 @@ def render_jinja(template_filename, **variables):
     )
     jenv.filters["datetime"] = datetime_format
     jenv.filters["label_color_css"] = label_color_css
+    jenv.filters["slugify"] = slugify
     template = jenv.get_template(template_filename)
     html = template.render(**variables)
     return html

--- a/src/dinghy/templates/digest.html.j2
+++ b/src/dinghy/templates/digest.html.j2
@@ -195,17 +195,21 @@
   }
   </style>
 </head>
-<body>
+<body id="top">
 
 <h1>{{ page_title() }}</h1>
+{% for container in results -%}
+  <a href="#{{ container.title | slugify }}">{{ container.title | trim }}</a>{% if not loop.last -%}&nbsp;|&nbsp;{%- endif -%}
+{% endfor -%}
 
 <ul class="repos">
   {% for container in results -%}
     <li>
-      <p><span class="reponame"><a href="{{ container.url }}">
+      <p><span class="reponame" id="{{ container.title | slugify }}"><a href="{{ container.url }}">
         {{- container.title|trim -}}
       </a></span>
       {{ container.container_kind }} {{ container.kind }}
+      <a style="float: right" href="#top">[back to top]</a>
       </p>
       {% if container.entries %}
         <ul class="entries">

--- a/src/dinghy/templates/digest.html.j2
+++ b/src/dinghy/templates/digest.html.j2
@@ -45,6 +45,12 @@
     line-height: 1.3;
     color: black;
   }
+  .navslugs {
+    margin-top: -1em;
+  }
+  .totop {
+    float: right;
+  }
   ul {
     padding-left: 0;
     list-style-type: none;
@@ -198,9 +204,15 @@
 <body id="top">
 
 <h1>{{ page_title() }}</h1>
-{% for container in results -%}
-  <a href="#{{ container.title | slugify }}">{{ container.title | trim }}</a>{% if not loop.last -%}&nbsp;|&nbsp;{%- endif -%}
-{% endfor -%}
+
+{% if results|length > 1 %}
+  <p class="navslugs">»
+    {% for container in results -%}
+      <a href="#{{ container.title | slugify }}">{{ container.title | trim }}</a>
+      {%- if not loop.last -%}&nbsp;|&nbsp;{%- endif -%}
+    {% endfor -%}
+  </p>
+{% endif %}
 
 <ul class="repos">
   {% for container in results -%}
@@ -209,7 +221,9 @@
         {{- container.title|trim -}}
       </a></span>
       {{ container.container_kind }} {{ container.kind }}
-      <a style="float: right" href="#top">[back to top]</a>
+      {% if results|length > 1 %}
+        <a class="totop" href="#top">[back to top]</a>
+      {% endif %}
       </p>
       {% if container.entries %}
         <ul class="entries">

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -7,7 +7,7 @@ import datetime
 import freezegun
 import pytest
 
-from dinghy.helpers import find_dict_with_key, parse_since, parse_timedelta
+from dinghy.helpers import find_dict_with_key, parse_since, parse_timedelta, slugify
 
 
 @pytest.mark.parametrize(
@@ -71,3 +71,7 @@ def test_parse_since(since, dtargs):
 )
 def test_find_dict_with_key(d, k, res):
     assert find_dict_with_key(d, k) == res
+
+
+def test_slugify():
+    assert slugify("Hello, World!") == "hello-world"


### PR DESCRIPTION
Hi. First things first: Thanks a stack for conceiving and maintaining this excellent program. We LOVE Dinghy.

After recently employing Dinghy as a recurrent job on Jenkins, and gradually adding more and more GitHub projects, the report pages became tedious to navigate, specifically with many items per section. So, why not introduce a breadcrumb section at the top of the page?
