### PR TITLE
helpers: backports only on < 3.11

### DIFF
--- a/src/dinghy/helpers.py
+++ b/src/dinghy/helpers.py
@@ -5,12 +5,15 @@ Misc helpers.
 import datetime
 import json
 import re
+import sys
 import unicodedata
 
 import aiofiles
-from backports.datetime_fromisoformat import MonkeyPatch
 
-MonkeyPatch.patch_fromisoformat()
+
+if sys.version_info < (3, 11):
+    from backports.datetime_fromisoformat import MonkeyPatch
+    MonkeyPatch.patch_fromisoformat()
 
 
 class DinghyError(Exception):


### PR DESCRIPTION
The `backports` module is not required in `pyproject.toml` for Python versions that are < 3.11. However, the import was non-conditional causing failures when the module is not available.

Guard the import on the same version as the dependency guard.

---

Should close/fix #45. I'd be OK with taking the `ImportError` approach instead of a version guard. Let me know what you think.